### PR TITLE
Enable editing for existing rows

### DIFF
--- a/components/css/SlickGrid.css
+++ b/components/css/SlickGrid.css
@@ -58,15 +58,14 @@
     color: black
 }
 
-.grid .slick-cell.editable {
-    padding: 0
-}
-
 .grid .slick-cell.editable input {
-    padding: .5em .8em .4em;
-    /* height: 100%; */
-    padding: .4em .65em .1em;
+    padding: .2em .65em .1em;
     letter-spacing: .03em
+	height: 100%;
+	outline: none;
+	border: none; 
+	color: inherit; 
+	background-color: transparent;
 }
 
 .grid .slick-cell.editable input:focus {

--- a/components/css/SlickGrid.css
+++ b/components/css/SlickGrid.css
@@ -17,7 +17,7 @@
 
 .grid {
     width: 100%;
-    height: 100%
+    height: 100%;
 }
 
 .grid .slick-header-column {
@@ -60,12 +60,12 @@
 
 .grid .slick-cell.editable input {
     padding: .2em .65em .1em;
-    letter-spacing: .03em
-	height: 100%;
-	outline: none;
-	border: none; 
-	color: inherit; 
-	background-color: transparent;
+    letter-spacing: .03em;
+    height: 100%;
+    outline: none;
+    border: none; 
+    color: inherit; 
+    background-color: transparent;
 }
 
 .grid .slick-cell.editable input:focus {

--- a/components/css/SlickGrid.css
+++ b/components/css/SlickGrid.css
@@ -64,7 +64,7 @@
 
 .grid .slick-cell.editable input {
     padding: .5em .8em .4em;
-    height: 100%;
+    /* height: 100%; */
     padding: .4em .65em .1em;
     letter-spacing: .03em
 }

--- a/components/css/SlickGrid.less
+++ b/components/css/SlickGrid.less
@@ -43,11 +43,11 @@
         &.editable {
             input {
                 padding: 0.2em 0.65em 0.1em;
-		height: 100%;
-		outline: none;
-		border: none; 
-		color: inherit; 
-		background-color: transparent;
+        height: 100%;
+        outline: none;
+        border: none; 
+        color: inherit; 
+        background-color: transparent;
                 letter-spacing: @grid-content-letter-spacing;
                 &:focus {
                     outline-offset: 0;

--- a/components/css/SlickGrid.less
+++ b/components/css/SlickGrid.less
@@ -43,11 +43,11 @@
         &.editable {
             input {
                 padding: 0.2em 0.65em 0.1em;
-        height: 100%;
-        outline: none;
-        border: none; 
-        color: inherit; 
-        background-color: transparent;
+                height: 100%;
+                outline: none;
+                border: none; 
+                color: inherit; 
+                background-color: transparent;
                 letter-spacing: @grid-content-letter-spacing;
                 &:focus {
                     outline-offset: 0;

--- a/components/css/SlickGrid.less
+++ b/components/css/SlickGrid.less
@@ -41,13 +41,14 @@
         }
 
         &.editable {
-            padding: 0;
             input {
                 .grid-cell-padding;
-                height: 100%;
                 padding: 0.4em 0.65em 0.1em;
+				height: 100%;
+				outline: none;
+				border: none; 
+				background-color: transparent;
                 letter-spacing: @grid-content-letter-spacing;
-
                 &:focus {
                     outline-offset: 0;
                 }

--- a/components/css/SlickGrid.less
+++ b/components/css/SlickGrid.less
@@ -44,10 +44,11 @@
             input {
                 .grid-cell-padding;
                 padding: 0.4em 0.65em 0.1em;
-				height: 100%;
-				outline: none;
-				border: none; 
-				background-color: transparent;
+		height: 100%;
+		outline: none;
+		border: none; 
+		color: inherit; 
+		background-color: transparent;
                 letter-spacing: @grid-content-letter-spacing;
                 &:focus {
                     outline-offset: 0;

--- a/components/css/SlickGrid.less
+++ b/components/css/SlickGrid.less
@@ -42,8 +42,7 @@
 
         &.editable {
             input {
-                .grid-cell-padding;
-                padding: 0.4em 0.65em 0.1em;
+                padding: 0.2em 0.65em 0.1em;
 		height: 100%;
 		outline: none;
 		border: none; 

--- a/components/js/SlickGrid.ts
+++ b/components/js/SlickGrid.ts
@@ -49,8 +49,16 @@ function getOverridableTextEditorClass(grid: SlickGrid): any {
         applyValue(item, state): void {
             let currentRow = grid.dataRows.at(this._rowIndex);
             let colIndex = grid.getColumnIndex(this._args.column.name);
-            currentRow.values[colIndex] = state;
-            this._textEditor.applyValue(item, state);
+            let dataLength: number = grid.dataRows.getLength();
+
+            if (this._rowIndex === dataLength) {
+                let rowToAdd: IGridDataRow = { values: [] };
+                rowToAdd.values[colIndex] = state;
+                // TODO add data to new row
+            } else {
+                currentRow.values[colIndex] = state;
+                this._textEditor.applyValue(item, state);
+            }
         };
 
         isValueChanged(): boolean {
@@ -95,7 +103,7 @@ export class SlickGrid implements OnChanges, OnInit, OnDestroy, AfterViewInit {
     @Input() enableAsyncPostRender: boolean = false;
     @Input() selectionModel: string = '';
     @Input() plugins: string[] = [];
-    @Input() enableEditing: boolean = false;
+    @Input() enableEditing: boolean = true;
     @Input() topRowNumber: number;
 
     @Input() isColumnEditable: (column: number) => boolean;
@@ -136,14 +144,14 @@ export class SlickGrid implements OnChanges, OnInit, OnDestroy, AfterViewInit {
     @Output() public enterEditSession(): void {
         let options: any = this._grid.getOptions();
         options.editable = true;
-        // options.enableAddRow = true;
+        options.enableAddRow = true;
         this._grid.setOptions(options);
     }
 
     @Output() public endEditSession(): void {
         let options: any = this._grid.getOptions();
         options.editable = false;
-        // options.enableAddRow = false;
+        options.enableAddRow = false;
         this._grid.setOptions(options);
     }
 
@@ -447,6 +455,7 @@ export class SlickGrid implements OnChanges, OnInit, OnDestroy, AfterViewInit {
             rowHeight: this._rowHeight,
             defaultColumnWidth: 120,
             editable: this.enableEditing,
+            enableAddRow: false,
             enableAsyncPostRender: this.enableAsyncPostRender,
             editorFactory: {
                 getEditor: this.getColumnEditor
@@ -602,6 +611,10 @@ export class SlickGrid implements OnChanges, OnInit, OnDestroy, AfterViewInit {
 
     private setCallbackOnDataRowsChanged(): void {
         if (this.dataRows) {
+            if (this.enableEditing) {
+                this.enterEditSession();
+            }
+
             this.dataRows.setCollectionChangedCallback((change: CollectionChange, startIndex: number, count: number) => {
                 this.renderGridDataRowsRange(startIndex, count);
             });

--- a/components/js/slickgrid.d.ts
+++ b/components/js/slickgrid.d.ts
@@ -37,7 +37,7 @@ export declare class SlickGrid implements OnChanges, OnInit, OnDestroy, AfterVie
         row: number;
         column: number;
     }>;
-    cellEditTryCommit: EventEmitter<{
+    cellEditExit: EventEmitter<{
         row: number;
         column: number;
         newValue: any;
@@ -45,7 +45,9 @@ export declare class SlickGrid implements OnChanges, OnInit, OnDestroy, AfterVie
     rowEditBegin: EventEmitter<{
         row: number;
     }>;
-    rowEditTryCommit: EventEmitter<void>;
+    rowEditExit: EventEmitter<{
+        row: number;
+    }>;
     onFocus(): void;
     private _grid;
     private _gridColumns;
@@ -60,6 +62,7 @@ export declare class SlickGrid implements OnChanges, OnInit, OnDestroy, AfterVie
     private _activeEditingRowHasChanges;
     enterEditSession(): void;
     endEditSession(): void;
+    private changeEditSession(enabled);
     getColumnIndex(name: string): number;
     handleEditorCellChange(rowNumber: number): void;
     private static getDataWithSchema(data, columns);

--- a/components/js/slickgrid.d.ts
+++ b/components/js/slickgrid.d.ts
@@ -23,28 +23,48 @@ export declare class SlickGrid implements OnChanges, OnInit, OnDestroy, AfterVie
     enableAsyncPostRender: boolean;
     selectionModel: string;
     plugins: string[];
+    enableEditing: boolean;
+    topRowNumber: number;
+    isColumnEditable: (column: number) => boolean;
+    isCellEditValid: (row: number, column: number, newValue: any) => boolean;
     loadFinished: EventEmitter<void>;
-    cellChanged: EventEmitter<{
-        column: string;
-        row: number;
-        newValue: any;
-    }>;
     editingFinished: EventEmitter<any>;
     contextMenu: EventEmitter<{
         x: number;
         y: number;
     }>;
-    topRowNumber: number;
     topRowNumberChange: EventEmitter<number>;
+    cellEditBegin: EventEmitter<{
+        row: number;
+        column: number;
+    }>;
+    cellEditTryCommit: EventEmitter<{
+        row: number;
+        column: number;
+        newValue: any;
+    }>;
+    rowEditBegin: EventEmitter<{
+        row: number;
+    }>;
+    rowEditTryCommit: EventEmitter<{
+        row: number;
+    }>;
     onFocus(): void;
     private _grid;
     private _gridColumns;
+    private _columnNameToIndex;
     private _gridData;
     private _rowHeight;
     private _resizeSubscription;
     private _gridSyncSubscription;
     private _topRow;
     private _leftPx;
+    private _activeEditingRow;
+    private _activeEditingRowHasChanges;
+    beginEditSession(): void;
+    endEditSession(): void;
+    getColumnIndex(name: string): number;
+    handleEditorCellChange(rowNumber: number): void;
     private static getDataWithSchema(data, columns);
     constructor(_el: any, _gridSyncService: any);
     ngOnChanges(changes: {
@@ -64,6 +84,7 @@ export declare class SlickGrid implements OnChanges, OnInit, OnDestroy, AfterVie
     private initGrid();
     private subscribeToScroll();
     private subscribeToCellChanged();
+    private subscribeToBeforeEditCell();
     private updateColumnWidths();
     subscribeToContextMenu(): void;
     private updateSchema();

--- a/components/js/slickgrid.d.ts
+++ b/components/js/slickgrid.d.ts
@@ -8,7 +8,6 @@ export declare class SlickGrid implements OnChanges, OnInit, OnDestroy, AfterVie
     columnDefinitions: IColumnDefinition[];
     dataRows: IObservableCollection<IGridDataRow>;
     resized: Observable<any>;
-    editableColumnIds: string[];
     highlightedCells: {
         row: number;
         column: number;

--- a/components/js/slickgrid.d.ts
+++ b/components/js/slickgrid.d.ts
@@ -46,9 +46,7 @@ export declare class SlickGrid implements OnChanges, OnInit, OnDestroy, AfterVie
     rowEditBegin: EventEmitter<{
         row: number;
     }>;
-    rowEditTryCommit: EventEmitter<{
-        row: number;
-    }>;
+    rowEditTryCommit: EventEmitter<void>;
     onFocus(): void;
     private _grid;
     private _gridColumns;
@@ -85,6 +83,7 @@ export declare class SlickGrid implements OnChanges, OnInit, OnDestroy, AfterVie
     private subscribeToScroll();
     private subscribeToCellChanged();
     private subscribeToBeforeEditCell();
+    private subscribeToActiveCellChanged();
     private updateColumnWidths();
     subscribeToContextMenu(): void;
     private updateSchema();

--- a/components/js/slickgrid.d.ts
+++ b/components/js/slickgrid.d.ts
@@ -61,7 +61,7 @@ export declare class SlickGrid implements OnChanges, OnInit, OnDestroy, AfterVie
     private _leftPx;
     private _activeEditingRow;
     private _activeEditingRowHasChanges;
-    beginEditSession(): void;
+    enterEditSession(): void;
     endEditSession(): void;
     getColumnIndex(name: string): number;
     handleEditorCellChange(rowNumber: number): void;

--- a/components/js/slickgrid.js
+++ b/components/js/slickgrid.js
@@ -57,8 +57,6 @@ function getOverridableTextEditorClass(grid) {
             if (this._rowIndex === dataLength) {
                 let rowToAdd = { values: [] };
                 rowToAdd.values[colIndex] = state;
-                let data = grid.dataRows;
-                data.push(rowToAdd);
             }
             else {
                 currentRow.values[colIndex] = state;

--- a/components/js/slickgrid.js
+++ b/components/js/slickgrid.js
@@ -53,8 +53,17 @@ function getOverridableTextEditorClass(grid) {
         applyValue(item, state) {
             let currentRow = grid.dataRows.at(this._rowIndex);
             let colIndex = grid.getColumnIndex(this._args.column.name);
-            currentRow.values[colIndex] = state;
-            this._textEditor.applyValue(item, state);
+            let dataLength = grid.dataRows.getLength();
+            if (this._rowIndex === dataLength) {
+                let rowToAdd = { values: [] };
+                rowToAdd.values[colIndex] = state;
+                let data = grid.dataRows;
+                data.push(rowToAdd);
+            }
+            else {
+                currentRow.values[colIndex] = state;
+                this._textEditor.applyValue(item, state);
+            }
         }
         ;
         isValueChanged() {
@@ -90,7 +99,7 @@ let SlickGrid = SlickGrid_1 = class SlickGrid {
         this.enableAsyncPostRender = false;
         this.selectionModel = '';
         this.plugins = [];
-        this.enableEditing = false;
+        this.enableEditing = true;
         this.loadFinished = new core_1.EventEmitter();
         this.editingFinished = new core_1.EventEmitter();
         this.contextMenu = new core_1.EventEmitter();
@@ -184,16 +193,16 @@ let SlickGrid = SlickGrid_1 = class SlickGrid {
     /* andresse: commented out 11/1/2016 due to minification issues
     private _finishGridEditingFn: (e: any, args: any) => void;
     */
-    beginEditSession() {
+    enterEditSession() {
         let options = this._grid.getOptions();
         options.editable = true;
-        // options.enableAddRow = true;
+        options.enableAddRow = true;
         this._grid.setOptions(options);
     }
     endEditSession() {
         let options = this._grid.getOptions();
         options.editable = false;
-        // options.enableAddRow = false;
+        options.enableAddRow = false;
         this._grid.setOptions(options);
     }
     getColumnIndex(name) {
@@ -378,6 +387,7 @@ let SlickGrid = SlickGrid_1 = class SlickGrid {
             rowHeight: this._rowHeight,
             defaultColumnWidth: 120,
             editable: this.enableEditing,
+            enableAddRow: false,
             enableAsyncPostRender: this.enableAsyncPostRender,
             editorFactory: {
                 getEditor: this.getColumnEditor
@@ -512,6 +522,9 @@ let SlickGrid = SlickGrid_1 = class SlickGrid {
     }
     setCallbackOnDataRowsChanged() {
         if (this.dataRows) {
+            if (this.enableEditing) {
+                this.enterEditSession();
+            }
             this.dataRows.setCollectionChangedCallback((change, startIndex, count) => {
                 this.renderGridDataRowsRange(startIndex, count);
             });
@@ -649,7 +662,7 @@ __decorate([
     __metadata('design:type', Function), 
     __metadata('design:paramtypes', []), 
     __metadata('design:returntype', void 0)
-], SlickGrid.prototype, "beginEditSession", null);
+], SlickGrid.prototype, "enterEditSession", null);
 __decorate([
     core_1.Output(), 
     __metadata('design:type', Function), 


### PR DESCRIPTION
This PR enables cells in existing rows to be edited. Callbacks are exposed via `@Output` that will notify components that cell edits or row edits have occurred. Optionally, components can provide `isColumnEditable` and `isCellEditValid` callbacks. 

This PR assumes that the component using angular2-slickgrid will update backend data based on the `rowEditTryCommit` callback. I.e. after this callback, angular2-slickgrid forgets that cell edits were made. 

More work has to be done to enable the "add new row" feature. This will involve setting `grid.options.enableAddRow = true`, among other things. 