### PR TITLE
Fix for column index bug 

### DIFF
--- a/components/js/SlickGrid.ts
+++ b/components/js/SlickGrid.ts
@@ -502,7 +502,7 @@ export class SlickGrid implements OnChanges, OnInit, OnDestroy, AfterViewInit {
 
     /* tslint:disable:member-ordering */
     private getColumnEditor = (column: any): any => {
-        if (this.isColumnEditable && !this.isColumnEditable(this.getColumnIndex(column))) {
+        if (this.isColumnEditable && !this.isColumnEditable(this.getColumnIndex(column.name))) {
             return undefined;
         }
 

--- a/components/js/slickgrid.js
+++ b/components/js/slickgrid.js
@@ -120,7 +120,7 @@ let SlickGrid = SlickGrid_1 = class SlickGrid {
         this._leftPx = 0;
         /* tslint:disable:member-ordering */
         this.getColumnEditor = (column) => {
-            if (this.isColumnEditable && !this.isColumnEditable(this.getColumnIndex(column))) {
+            if (this.isColumnEditable && !this.isColumnEditable(this.getColumnIndex(column.name))) {
                 return undefined;
             }
             let columnId = column.id;


### PR DESCRIPTION
This PR addresses a bug in the `isColumnEditable`  output function where the proper name was not being passed. 