### PR TITLE
add check to only scroll if we have data to scroll

### DIFF
--- a/components/js/slickGrid.ts
+++ b/components/js/slickGrid.ts
@@ -277,7 +277,9 @@ export class SlickGrid implements OnChanges, OnInit, OnDestroy, AfterViewInit {
         if (this.topRowNumber === undefined) {
             this.topRowNumber = 0;
         }
-        this._grid.scrollRowToTop(this.topRowNumber);
+        if (this.dataRows && this.dataRows.getLength() > 0) {
+            this._grid.scrollRowToTop(this.topRowNumber);
+        }
 
         if (this.resized) {
             // Re-rendering the grid is expensive. Throttle so we only do so every 100ms.


### PR DESCRIPTION
Fixes a bug when we try and scroll with no data and slickgrid calculates bad data.