### PR TITLE
expose onBeforeAppendCell event

### DIFF
--- a/components/js/slickGrid.ts
+++ b/components/js/slickGrid.ts
@@ -30,7 +30,7 @@ export function getOverridableTextEditorClass(grid: SlickGrid): any {
         public keyCaptureList: number[];
 
         constructor(private _args: any) {
-            this._textEditor = new Slick.Editors.Text(_args);            
+            this._textEditor = new Slick.Editors.Text(_args);
             const END = 35;
             const HOME = 36;
 
@@ -130,6 +130,7 @@ export class SlickGrid implements OnChanges, OnInit, OnDestroy, AfterViewInit {
 
     @Input() overrideCellFn: (rowNumber, columnId, value?, data?) => string;
     @Input() isCellEditValid: (row: number, column: number, newValue: any) => boolean;
+    @Input() getAdditionalCssClassesForCell: (row: number, column: number) => string;
 
     @Output() loadFinished: EventEmitter<void> = new EventEmitter<void>();
 
@@ -499,6 +500,9 @@ export class SlickGrid implements OnChanges, OnInit, OnDestroy, AfterViewInit {
         });
         this._grid.onContextMenu.subscribe((e, args) => {
             this.onContextMenu.emit(e);
+        });
+        this._grid.onBeforeAppendCell.subscribe((e, args) => {
+            return this.getAdditionalCssClassesForCell ? this.getAdditionalCssClassesForCell(args.row, args.cell) : undefined;
         });
     }
 

--- a/components/typings/slick.d.ts
+++ b/components/typings/slick.d.ts
@@ -1203,6 +1203,7 @@ declare namespace Slick {
 		public onSelectedRowsChanged: Slick.Event<OnSelectedRowsChangedEventArgs<T>>;
 		public onCellCssStylesChanged: Slick.Event<OnCellCssStylesChangedEventArgs<T>>;
 		public onViewportChanged: Slick.Event<OnViewportChangedEventArgs<T>>;
+		public onBeforeAppendCell:Slick.Event<OnBeforeAppendCellEventArgs<T>>
 		// #endregion Events
 
 		// #region Plugins
@@ -1403,6 +1404,13 @@ declare namespace Slick {
 
 	export interface OnViewportChangedEventArgs<T extends SlickData> extends GridEventArgs<T> {
 
+	}
+	
+	export interface OnBeforeAppendCellEventArgs<T extends SlickData> extends GridEventArgs<T>{
+		row: number;
+		cell: number;
+		value: any;
+		dataContext: any;
 	}
 
 	export interface SortColumn<T extends SlickData> {


### PR DESCRIPTION
need to utilize the onBeforeAppendCell event of slickgrid to improve the ADS edit data feature.